### PR TITLE
Security patch for RegEx DoS exploit

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "keywords": ["logging", "sysadmin", "tools", "winston", "couchdb"],
   "license": "MIT",
   "dependencies": {
-    "cradle": "0.6.x",
+    "cradle": "https://github.com/shirakaba/cradle/tarball/shirakaba-security-redos",
     "cycle": "1.0.x"
   },
   "devDependencies": {


### PR DESCRIPTION
OVERVIEW

Affected versions of debug are vulnerable to regular expression denial of service when untrusted user input is passed into the o formatter.

As it takes 50,000 characters to block the event loop for 2 seconds, this issue is a low severity issue.

REMEDIATION

Version 2.x.x: Update to version 2.6.9 or later. Version 3.x.x: Update to version 3.1.0 or later.